### PR TITLE
Added a base typography file, to reset default heading styling.

### DIFF
--- a/sass/base/heading.scss
+++ b/sass/base/heading.scss
@@ -20,7 +20,6 @@ h6,
     margin: 0 0 .8rem;
     line-height: 1.3;
     font-size: 2.4rem;
-    font-weight: 500;
 }
 
 h1, .head1 	{ font-size: 3.0rem; margin-bottom: .2rem; }

--- a/sass/base/heading.scss
+++ b/sass/base/heading.scss
@@ -1,5 +1,5 @@
 /*	HEADERS
-*	Always try to use .head class + .head1-6 for SEO reasons
+*	Always try to use a .head class for SEO reasons
 *	Only style on h1-h6 when the client uses an editor like TinyMCE and you can't influence the classes
 */
 
@@ -16,6 +16,7 @@ h6,
 .head4,
 .head5,
 .head6 {
+	font-family: $font-sec;
     margin: 0 0 .8rem;
     line-height: 1.3;
     font-size: 2.4rem;
@@ -27,4 +28,4 @@ h2, .head2 	{ font-size: 2.6rem; margin-bottom: .3rem; }
 h3, .head3 	{ font-size: 2.4rem; margin-bottom: .2rem; }
 h4, .head4 	{ font-size: 2.2rem; margin-bottom: .2rem; }
 h5, .head5 	{ font-size: 2.0rem; margin-bottom: .4rem; }
-h6, .head6 	{ font-size: 1.6rem; font-weight: bold; }
+h6, .head6 	{ font-size: 1.6rem; margin-bottom: .6rem; }

--- a/sass/base/typography.scss
+++ b/sass/base/typography.scss
@@ -1,6 +1,6 @@
 /*	HEADERS
 *	Always try to use .head class + .head1-6 for SEO reasons
-*	Only style on h1-h6 for user placable (free) content blocks.
+*	Only style on h1-h6 when the client uses an editor like TinyMCE and you can't influence the classes
 */
 
 h1,

--- a/sass/base/typography.scss
+++ b/sass/base/typography.scss
@@ -1,0 +1,30 @@
+/*	HEADERS
+*	Always try to use .head class + .head1-6 for SEO reasons
+*	Only style on h1-h6 for user placable (free) content blocks.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.head,
+.head1,
+.head2,
+.head3,
+.head4,
+.head5,
+.head6 {
+    margin: 0 0 .8rem;
+    line-height: 1.3;
+    font-size: 2.4rem;
+    font-weight: 500;
+}
+
+h1, .head1 	{ font-size: 3.0rem; margin-bottom: .2rem; }
+h2, .head2 	{ font-size: 2.6rem; margin-bottom: .3rem; }
+h3, .head3 	{ font-size: 2.4rem; margin-bottom: .2rem; }
+h4, .head4 	{ font-size: 2.2rem; margin-bottom: .2rem; }
+h5, .head5 	{ font-size: 2.0rem; margin-bottom: .4rem; }
+h6, .head6 	{ font-size: 1.6rem; font-weight: bold; }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -9,4 +9,4 @@
 	These base files here so they overwrite the grid
 */
 @import 'base/defaults';
-@import 'base/typography';
+@import 'base/heading';

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -6,6 +6,7 @@
 @import 'layout/static_content';
 
 /* 	Base
-	These base files here so they overwrite the grid  
+	These base files here so they overwrite the grid
 */
 @import 'base/defaults';
+@import 'base/typography';


### PR DESCRIPTION
@dariusrosendahl, in order to deal with top margins on top of headings, I included the file typography.scss. Could you or @CastleCSS/front-end review the issue? 